### PR TITLE
Add swagger to auto generate API documents

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,11 @@ module.exports = {
       'error',
       'never',
     ],
+    'comma-dangle': [
+      'error', {
+        arrays: 'always-multiline',
+        objects: 'always-multiline',
+      },
+    ],
   },
 }

--- a/app.js
+++ b/app.js
@@ -1,22 +1,12 @@
 const express = require('express')
 const swaggerUi = require('swagger-ui-express')
-const yaml = require('yamljs')
 
-const swaggerDoc = yaml.load('./swagger.yaml')
+const swaggerOptions = require('./docs/options.config')
+const swaggerDoc = require('./docs/index')
 const routes = require('./routes')
 
 const PORT = process.env.PORT || 3000
 const app = express()
-
-const swaggerOptions = {
-  // sort operation orders
-  operationsSorter(a, b) {
-    const order = {
-      get: '0', post: '1', put: '2', delete: '3',
-    }
-    return order[a.get('method')].localeCompare(order[b.get('method')])
-  },
-}
 
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))

--- a/app.js
+++ b/app.js
@@ -1,7 +1,32 @@
 const express = require('express')
+const swaggerUi = require('swagger-ui-express')
+const yaml = require('yamljs')
+
+const swaggerDoc = yaml.load('./swagger.yaml')
+const routes = require('./routes')
 
 const PORT = process.env.PORT || 3000
 const app = express()
+
+const swaggerOptions = {
+  // sort operation orders
+  operationsSorter(a, b) {
+    const order = {
+      get: '0', post: '1', put: '2', delete: '3',
+    }
+    return order[a.get('method')].localeCompare(order[b.get('method')])
+  },
+}
+
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
+
+app.use(
+  '/api-docs',
+  swaggerUi.serve,
+  swaggerUi.setup(swaggerDoc, swaggerOptions)
+)
+app.use('/', routes)
 
 /* eslint-disable no-console */
 app.listen(PORT, () => {

--- a/docs/basicInfo.js
+++ b/docs/basicInfo.js
@@ -1,0 +1,14 @@
+module.exports = {
+  // supported openapi version
+  openapi: '3.0.3',
+
+  info: {
+    title: 'Attendace - system(線上出勤管理系統)',
+    description: '提供企業員工使用線上打卡或 QRcode 方式掃碼打卡。\n打卡系統採用定位方式限制，不得於公司 400 公尺外進行系統登入。',
+    version: '1.0.0',
+    contact: {
+      name: 'Rita Chien',
+      email: 'ritachien929@gmail.com',
+    },
+  },
+}

--- a/docs/components.js
+++ b/docs/components.js
@@ -1,0 +1,15 @@
+const apiResponse = require('./schemas/apiResponse')
+
+module.exports = {
+  securitySchemes: {
+    bearerAuth: {
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+    },
+  },
+  schemas: {
+    // api response model
+    apiResponse,
+  },
+}

--- a/docs/index.js
+++ b/docs/index.js
@@ -1,0 +1,13 @@
+const basicInfo = require('./basicInfo')
+const servers = require('./servers')
+const tags = require('./tags')
+const paths = require('./paths/index')
+const components = require('./components')
+
+module.exports = {
+  ...basicInfo,
+  ...servers,
+  ...tags,
+  paths,
+  components,
+}

--- a/docs/options.config.js
+++ b/docs/options.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  // sort operation orders
+  operationsSorter(a, b) {
+    const order = {
+      get: '0', post: '1', put: '2', delete: '3',
+    }
+    return order[a.get('method')].localeCompare(order[b.get('method')])
+  },
+}

--- a/docs/paths/index.js
+++ b/docs/paths/index.js
@@ -1,0 +1,5 @@
+const userLogin = require('./userLogin')
+
+module.exports = {
+  '/users/login': userLogin,
+}

--- a/docs/paths/userLogin.js
+++ b/docs/paths/userLogin.js
@@ -1,0 +1,45 @@
+module.exports = {
+  post: {
+    tags: [
+      'Auth',
+    ],
+    summary: '員工登入',
+    description: '員工輸入帳號/密碼登入成功後，server 會回傳身分驗證 Token。',
+    operationId: 'userLogin',
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              account: {
+                type: 'string',
+                example: 'user1',
+              },
+              password: {
+                type: 'string',
+                example: '12345678',
+              },
+            },
+            required: [
+              'account',
+              'password',
+            ],
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: '成功登入',
+      },
+      401: {
+        description: '帳號或密碼錯誤',
+      },
+      500: {
+        description: 'server error',
+      },
+    },
+  },
+}

--- a/docs/schemas/apiResponse.js
+++ b/docs/schemas/apiResponse.js
@@ -1,0 +1,17 @@
+module.exports = {
+  type: 'object',
+  properties: {
+    status: {
+      type: 'string',
+      example: 'success',
+    },
+    message: {
+      type: 'string',
+      description: 'short description of request result',
+    },
+    data: {
+      type: 'object',
+      description: 'some return data if exists',
+    },
+  },
+}

--- a/docs/servers.js
+++ b/docs/servers.js
@@ -1,0 +1,8 @@
+module.exports = {
+  servers: [
+    {
+      url: 'http://localhost:3000',
+      description: 'Development',
+    },
+  ],
+}

--- a/docs/tags.js
+++ b/docs/tags.js
@@ -1,0 +1,8 @@
+module.exports = {
+  tags: [
+    {
+      name: 'Auth',
+      description: '身分驗證相關路由',
+    },
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.2",
-    "swagger-ui-express": "^4.6.0",
-    "yamljs": "^0.3.0"
+    "swagger-ui-express": "^4.6.0"
   },
   "devDependencies": {
     "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "swagger-ui-express": "^4.6.0",
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "dotenv": "^16.0.3",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,7 @@
+const router = require('express').Router()
+
+router.post('/users/login', (req, res) => {
+  res.status(200).send('Hello world')
+})
+
+module.exports = router

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.3
+info:
+  title: Attendace-system(線上出勤管理系統)
+  description: |
+    提供企業員工使用線上打卡或 QRcode 方式掃碼打卡。
+    打卡系統採用定位方式限制，不得於公司 400 公尺外進行系統登入。
+  contact:
+    email: ritachien929@gmail.com
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+
+# Domain of server(array)
+servers:
+  - description: Development
+    url: http://localhost:3000
+# Categories of APIs(array)
+tags:
+  - name: Auth
+    description: 身分驗證相關路由。
+
+# API paths
+paths:
+  /users/login:
+    post:
+      tags: [Auth]
+      summary: 員工登入
+      description: 員工輸入帳號/密碼登入成功後，server 會回傳身分驗證 Token。
+      operationId: userLogin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                account:
+                  type: string
+                  example: "user1"
+                password:
+                  type: string
+                  example: "12345678"
+              required: [account, password]
+      responses:
+        "200":
+          description: 成功登入
+        "401":
+          description: 帳號或密碼錯誤
+        "500":
+          description: server error

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,13 +115,6 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-argparse@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
-  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
-  dependencies:
-    sprintf-js "~1.0.2"
-
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
@@ -750,7 +743,7 @@ glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.5, glob@^7.1.3:
+glob@^7.1.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -1477,11 +1470,6 @@ simple-update-notifier@^1.0.7:
   dependencies:
     semver "~7.0.0"
 
-sprintf-js@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
-  integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
-
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
@@ -1671,14 +1659,6 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
-
-yamljs@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.3.0.tgz#dc060bf267447b39f7304e9b2bfbe8b5a7ddb03b"
-  integrity sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==
-  dependencies:
-    argparse "^1.0.7"
-    glob "^7.0.5"
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,6 +115,13 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
+
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
@@ -743,7 +750,7 @@ glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.3:
+glob@^7.0.5, glob@^7.1.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -1470,6 +1477,11 @@ simple-update-notifier@^1.0.7:
   dependencies:
     semver "~7.0.0"
 
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
@@ -1528,6 +1540,18 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+swagger-ui-dist@>=4.11.0:
+  version "4.15.5"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-4.15.5.tgz#cda226a79db2a9192579cc1f37ec839398a62638"
+  integrity sha512-V3eIa28lwB6gg7/wfNvAbjwJYmDXy1Jo1POjyTzlB6wPcHiGlRxq39TSjYGVjQrUSAzpv+a7nzp7mDxgNy57xA==
+
+swagger-ui-express@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/swagger-ui-express/-/swagger-ui-express-4.6.0.tgz#fc297d80c614c80f5d7def3dab50b56428cfe1c9"
+  integrity sha512-ZxpQFp1JR2RF8Ar++CyJzEDdvufa08ujNUJgMVTMWPi86CuQeVdBtvaeO/ysrz6dJAYXf9kbVNhWD7JWocwqsA==
+  dependencies:
+    swagger-ui-dist ">=4.11.0"
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -1647,6 +1671,14 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+yamljs@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.3.0.tgz#dc060bf267447b39f7304e9b2bfbe8b5a7ddb03b"
+  integrity sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==
+  dependencies:
+    argparse "^1.0.7"
+    glob "^7.0.5"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
1. 引入 swagger-express-ui 來自動生成互動式 API 文件，讓使用者能直觀了解 input 跟 output 結構。
2. 為了讓 Git diff 呈現更簡潔，有一併在 lint rules 裡調整 array 和 object 行末逗號規則。