### PR TITLE
【edge case】打下班卡時剛好遇到換日處理

### DIFF
--- a/utils/dateHelpers.js
+++ b/utils/dateHelpers.js
@@ -25,13 +25,8 @@ function isHoliday (date) {
   return calendar[index].isHoliday
 }
 
-function isNotToday (date) {
-  return !dayjs(date).isToday()
-}
-
 module.exports = {
   getRecordDate,
   getDuration,
   isHoliday,
-  isNotToday,
 }


### PR DESCRIPTION
原本的邏輯容易因為 request payload 出現 edge case，現在把打卡時間
的資料生成改由後端進行，減少問題發生機率跟簡化檢查流程

* clock 時間由後端產生
1. 不須檢查 payload 是否包含時間
2. 不須檢查時間的日期是否是打卡當下

* 同時檢查 record date 和當下的打卡日是否一致
1. 避免打下班卡當下剛好遇到換日